### PR TITLE
Fix user thread scheduling logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror -fno-omit-frame-pointer
+CFLAGS += -Wno-error=infinite-recursion -Wno-error=maybe-uninitialized -Wno-error=array-bounds
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 ASFLAGS = -m32 -gdwarf-2 -Wa,-divide
 # FreeBSD ld wants ``elf_i386_fbsd''

--- a/proc.c
+++ b/proc.c
@@ -89,6 +89,7 @@ found:
   p->state = EMBRYO;
   p->pid = nextpid++;
   p->scheduler = 0;
+  p->sched_pending = 0;
 
   release(&ptable.lock);
 
@@ -211,6 +212,7 @@ fork(void)
 
   safestrcpy(np->name, curproc->name, sizeof(curproc->name));
   np->scheduler = curproc->scheduler;
+  np->sched_pending = 0;
 
   pid = np->pid;
 

--- a/proc.h
+++ b/proc.h
@@ -47,6 +47,7 @@ struct proc {
   void *chan;                  // If non-zero, sleeping on chan
   int killed;                  // If non-zero, have been killed
   uint scheduler;              // address of user level scheduler function
+  int sched_pending;           // call user scheduler on return to user space
   struct file *ofile[NOFILE];  // Open files
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)

--- a/sysproc.c
+++ b/sysproc.c
@@ -102,6 +102,7 @@ sys_uthread_create(void)
   p = myproc();
   if(p->scheduler == 0)
     p->scheduler = (uint)func;
+  p->sched_pending = 0;
 
   return 0;
 }

--- a/trap.c
+++ b/trap.c
@@ -43,6 +43,12 @@ trap(struct trapframe *tf)
     syscall();
     if(myproc()->killed)
       exit();
+    if(myproc()->sched_pending && myproc()->scheduler && (tf->cs&3) == DPL_USER){
+      myproc()->sched_pending = 0;
+      tf->esp -= 4;
+      *(uint*)tf->esp = tf->eip;
+      tf->eip = myproc()->scheduler;
+    }
     return;
   }
 
@@ -55,10 +61,14 @@ trap(struct trapframe *tf)
       release(&tickslock);
     }
     lapiceoi();
-    if(myproc() && myproc()->scheduler && (tf->cs&3) == DPL_USER){
-      tf->esp -= 4;
-      *(uint*)tf->esp = tf->eip;
-      tf->eip = myproc()->scheduler;
+    if(myproc() && myproc()->scheduler){
+      if((tf->cs&3) == DPL_USER){
+        tf->esp -= 4;
+        *(uint*)tf->esp = tf->eip;
+        tf->eip = myproc()->scheduler;
+      } else {
+        myproc()->sched_pending = 1;
+      }
     }
     break;
   case T_IRQ0 + IRQ_IDE:
@@ -110,6 +120,13 @@ trap(struct trapframe *tf)
   if(myproc() && myproc()->state == RUNNING &&
      tf->trapno == T_IRQ0+IRQ_TIMER)
     yield();
+
+  if(myproc() && myproc()->sched_pending && (tf->cs&3) == DPL_USER && myproc()->scheduler){
+    myproc()->sched_pending = 0;
+    tf->esp -= 4;
+    *(uint*)tf->esp = tf->eip;
+    tf->eip = myproc()->scheduler;
+  }
 
   // Check if the process has been killed since we yielded
   if(myproc() && myproc()->killed && (tf->cs&3) == DPL_USER)

--- a/uthread.c
+++ b/uthread.c
@@ -35,10 +35,14 @@ thread_init(void)
   current_thread->state = RUNNING;
 }
 
-static void 
+static void
 thread_schedule(void)
 {
   thread_p t;
+
+  // If the current thread was preempted, mark it runnable
+  if(current_thread != &all_thread[0] && current_thread->state == RUNNING)
+    current_thread->state = RUNNABLE;
 
   /* Find another runnable thread. */
   next_thread = 0;


### PR DESCRIPTION
## Summary
- add extra gcc flags for new compilers
- mark preempted threads as runnable before scheduling
- handle preemption during system calls by deferring user scheduler call

## Testing
- `make fs.img`
- `make CPUS=1 qemu-nox` *(fails: qemu missing)*